### PR TITLE
[Task] Start/End dates support strings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    periodoxical (0.3.2)
+    periodoxical (0.4.2)
       tzinfo (~> 2.0, >= 2.0.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Periodoxical.generate(
       end_time: '2:30PM'
     }
   ],
-  start_date: Date.parse('2024-05-23'),
-  end_date: Date.parse('2024-06-12')
+  start_date: '2024-05-23',
+  end_date: '2024-06-12',
 )
 # returns an array of hashes, each with :start and :end keys
 #=> 
@@ -93,7 +93,7 @@ Periodoxical.generate(
       end_time: '2:30PM'
     }
   ],
-  start_date: Date.parse('2024-05-23'),
+  start_date: Date.parse('2024-05-23'), # Can also pass in `Date` object.
   limit: 3
 )
 # =>
@@ -120,8 +120,8 @@ As a ruby dev, I want to generate all the timeblocks between May 23, 2024 and Ju
 ```rb
 Periodoxical.generate(
   time_zone: 'America/Los_Angeles',
-  start_date: Date.parse('2024-05-23'),
-  end_date: Date.parse('2024-06-12'),
+  start_date: Date.parse('2024-05-23'), # can also pass in Date objects
+  end_date: Date.parse('2024-06-12'), # can also pass in Date objects,
   day_of_week_time_blocks: {
     mon: [
       { start_time: '8:00AM', end_time: '9:00AM' },

--- a/lib/periodoxical.rb
+++ b/lib/periodoxical.rb
@@ -15,8 +15,8 @@ module Periodoxical
     # @param [String] time_zone
     #   Ex: 'America/Los_Angeles', 'America/Chicago',
     #   TZInfo::DataTimezone#name from the tzinfo gem (https://github.com/tzinfo/tzinfo)
-    # @param [Date] start_date
-    # @param [Date] end_date
+    # @param [Date, String] start_date
+    # @param [Date, String] end_date
     # @param [Array<Hash>] time_blocks
     #   Ex: [
     #     {
@@ -47,8 +47,8 @@ module Periodoxical
       @days_of_week = days_of_week
       @time_blocks = time_blocks
       @day_of_week_time_blocks = day_of_week_time_blocks
-      @start_date = start_date
-      @end_date = end_date
+      @start_date = start_date.is_a?(String) ? Date.parse(start_date) : start_date
+      @end_date = end_date.is_a?(String) ? Date.parse(end_date) : end_date
       @limit = limit
       validate!
     end

--- a/lib/periodoxical/version.rb
+++ b/lib/periodoxical/version.rb
@@ -1,3 +1,3 @@
 module Periodoxical
-  VERSION = "0.3.2"
+  VERSION = "0.4.2"
 end

--- a/spec/periodoxical_spec.rb
+++ b/spec/periodoxical_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Periodoxical do
               end_time: '2:30PM'
             }
           ],
-          start_date: Date.parse('2024-05-23'),
-          end_date: Date.parse('2024-06-12')
+          start_date: '2024-05-23',
+          end_date: '2024-06-12',
         )
       end
 


### PR DESCRIPTION
`start_date` and `end_date` keys can be strings in addition to `Date` objects.