### PR TITLE
Add DST edge case handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,39 @@ Periodoxical.generate(
 ]
 ```
 
+### Daylight Saving Time (DST) handling
+
+Periodoxical supports explicit strategies for DST edge cases when converting local times to UTC:
+
+- ambiguous_time: how to resolve fall-back ambiguous local times (e.g., 01:30 occurs twice)
+  - :first → choose the first occurrence (usually daylight time)
+  - :last → choose the second occurrence (standard time)
+  - :raise → raise TZInfo::AmbiguousTime (default)
+- gap_strategy: how to handle spring-forward missing local times (e.g., 02:30 does not exist)
+  - :advance → move forward by gap_shift_minutes to the next valid local time
+  - :skip → drop the invalid block
+  - :raise → raise TZInfo::PeriodNotFound (default)
+- gap_shift_minutes: integer minutes to advance when gap_strategy is :advance (default: 60)
+
+Example: be resilient around DST changes
+
+```rb
+Periodoxical.generate(
+  time_zone: 'America/Los_Angeles',
+  ambiguous_time: :last,      # pick standard time on fall back
+  gap_strategy: :advance,     # move to next valid time on spring forward
+  gap_shift_minutes: 60,
+  starting_from: '2025-03-01',
+  ending_at:   '2025-11-30',
+  time_blocks: [ { start_time: '1:30AM', end_time: '2:30AM' } ]
+)
+```
+
+Notes:
+- Period offsets are applied based on the period at that instant, not the current period.
+- If you choose `gap_strategy: :skip`, blocks that convert to invalid local times will be omitted.
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/periodoxical.rb
+++ b/lib/periodoxical.rb
@@ -160,7 +160,7 @@ module Periodoxical
 
     # @param [String] time_str
     #   Ex: '9:00AM'
-    # @param [Date] date
+    # @return [Date] date
     #
     # Converts a local date and time string to UTC and returns a DateTime with the
     # timezone offset corresponding to the zone period at that instant.

--- a/lib/periodoxical.rb
+++ b/lib/periodoxical.rb
@@ -71,6 +71,14 @@ module Periodoxical
     #     - 9:00AM - 9:20AM
     #     - 9:20AM - 9:40AM
     #     - 9:40AM - 10:00AM
+    # @param [Symbol] ambiguous_time
+    #   How to resolve DST fall-back ambiguous local times (e.g. 01:30 occurs twice).
+    #   Allowed: :first (daylight time), :last (standard time), :raise (default).
+    # @param [Symbol] gap_strategy
+    #   How to handle DST spring-forward missing local times (e.g. 02:30 does not exist).
+    #   Allowed: :advance (shift forward), :skip (omit block), :raise (default).
+    # @param [Integer] gap_shift_minutes
+    #   Minutes to advance when gap_strategy is :advance. Default: 60.
     def initialize(
       starting_from:,
       ending_at: nil,
@@ -84,10 +92,16 @@ module Periodoxical
       nth_day_of_week_in_month: nil,
       days_of_month: nil,
       duration: nil,
-      months: nil
+      months: nil,
+      ambiguous_time: :raise,
+      gap_strategy: :raise,
+      gap_shift_minutes: 60
     )
 
       @time_zone = TZInfo::Timezone.get(time_zone)
+      @ambiguous_time = ambiguous_time
+      @gap_strategy = gap_strategy
+      @gap_shift_minutes = gap_shift_minutes
       if days_of_week.is_a?(Array)
         @days_of_week = deep_symbolize_keys(days_of_week)
       elsif days_of_week.is_a?(Hash)
@@ -147,6 +161,12 @@ module Periodoxical
     # @param [String] time_str
     #   Ex: '9:00AM'
     # @param [Date] date
+    #
+    # Converts a local date and time string to UTC and returns a DateTime with the
+    # timezone offset corresponding to the zone period at that instant.
+    # Handles DST transitions explicitly:
+    #  - Ambiguous (fall-back) times resolved via `@ambiguous_time`.
+    #  - Missing (spring-forward) times handled via `@gap_strategy` and `@gap_shift_minutes`.
     def time_str_to_object(date, time_str)
       time = Time.strptime(time_str, '%I:%M%p')
       date_time = DateTime.new(
@@ -157,7 +177,51 @@ module Periodoxical
         time.min,
         time.sec,
       )
-      @time_zone.local_to_utc(date_time).new_offset(@time_zone.current_period.offset.utc_total_offset)
+      utc_time = begin
+        @time_zone.local_to_utc(date_time) do |periods|
+          case @ambiguous_time
+          when :first
+            periods.first
+          when :last
+            periods.last
+          when :raise
+            raise TZInfo::AmbiguousTime, date_time.to_s
+          else
+            periods.last
+          end
+        end
+      rescue TZInfo::AmbiguousTime
+        case @ambiguous_time
+        when :first
+          @time_zone.local_to_utc(date_time) { |periods| periods.first }
+        when :last
+          @time_zone.local_to_utc(date_time) { |periods| periods.last }
+        else
+          raise
+        end
+      rescue TZInfo::PeriodNotFound
+        case @gap_strategy
+        when :advance
+          step = Rational(@gap_shift_minutes, 24 * 60)
+          shifted = date_time
+          attempts = 0
+          begin
+            shifted += step
+            attempts += 1
+            raise TZInfo::PeriodNotFound if attempts > 240
+            @time_zone.local_to_utc(shifted)
+          rescue TZInfo::PeriodNotFound
+            retry
+          end
+        when :skip
+          return nil
+        else
+          raise
+        end
+      end
+
+      period_at_utc = @time_zone.period_for_utc(utc_time)
+      utc_time.new_offset(period_at_utc.offset.utc_total_offset)
     end
 
     # @param [Date] date
@@ -211,6 +275,8 @@ module Periodoxical
     def append_to_output_and_check_limit(time_block)
       strtm = time_str_to_object(@current_date, time_block[:start_time])
       endtm = time_str_to_object(@current_date, time_block[:end_time])
+
+      return if strtm.nil? || endtm.nil?
 
       if @duration
         split_by_duration_and_append(strtm, endtm)
@@ -395,6 +461,7 @@ module Periodoxical
 
       if @starting_from.is_a?(DateTime)
         start_time = time_str_to_object(@current_date, time_block[:start_time])
+        return false if start_time.nil?
 
         # If the candidate time block is starting earlier than @starting_from, we want to skip it
         return true if start_time < @starting_from
@@ -402,6 +469,7 @@ module Periodoxical
 
       if @ending_at.is_a?(DateTime)
         end_time = time_str_to_object(@current_date, time_block[:end_time])
+        return false if end_time.nil?
 
         # If the candidate time block is ending after @ending_at, we want to skip it
         return true if end_time > @ending_at

--- a/lib/periodoxical.rb
+++ b/lib/periodoxical.rb
@@ -160,8 +160,9 @@ module Periodoxical
 
     # @param [String] time_str
     #   Ex: '9:00AM'
-    # @return [Date] date
+    # @param [Date] date
     #
+    # @return [DateTime]
     # Converts a local date and time string to UTC and returns a DateTime with the
     # timezone offset corresponding to the zone period at that instant.
     # Handles DST transitions explicitly:

--- a/lib/periodoxical/version.rb
+++ b/lib/periodoxical/version.rb
@@ -1,3 +1,3 @@
 module Periodoxical
-  VERSION = "2.2.1"
+  VERSION = "2.3.0"
 end


### PR DESCRIPTION
This PR attempts to address an issue a consuming application can encounter when a time range includes a window of time that is during a daylight savings time shift, resulting in a thrown `TZInfo::AmbiguousTime` error.

The specific example we encountered:
```
TZInfo::AmbiguousTime: 2025-11-02 01:30:00 is an ambiguous local time.
```
On November 2, 2025, at 2:00 AM, clocks "fall back" to 1:00 AM (DST → Standard Time). This means the hour from 1:00-2:00 AM occurs twice, making times like 1:30 AM ambiguous.

This PR adds some optional parameters to the `#generate` method that let consumers specify how they want to handle DST edge cases in order to be resilient and not throw AmbiguousTime errors.

Includes a minor version bump